### PR TITLE
June - final merge

### DIFF
--- a/argocd-apps/apps/jiggler-app.yaml
+++ b/argocd-apps/apps/jiggler-app.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/Neilrw86/k8s-jiggler.git # The Git repository URL where your chart is located
     path: helm_charts/k8s-jiggler # The path to your Helm chart directory within the repository
-    targetRevision: HEAD # Or a specific branch, tag, or commit hash (e.g., main, v0.1.0)
+    targetRevision: June # Or a specific branch, tag, or commit hash (e.g., main, v0.1.0)
 
     helm:
       # Example: To make k8s-jiggler only watch pods within its own deployment namespace ('k8s-jiggler')

--- a/argocd-apps/apps/jiggler-app.yaml
+++ b/argocd-apps/apps/jiggler-app.yaml
@@ -10,7 +10,7 @@ spec:
 
   source:
     repoURL: https://github.com/Neilrw86/k8s-jiggler.git # The Git repository URL where your chart is located
-    path: k8s-jiggler # The path to your Helm chart directory within the repository
+    path: helm_charts/k8s-jiggler # The path to your Helm chart directory within the repository
     targetRevision: HEAD # Or a specific branch, tag, or commit hash (e.g., main, v0.1.0)
 
     helm:

--- a/argocd-apps/apps/jiggler-app.yaml
+++ b/argocd-apps/apps/jiggler-app.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: k8s-jiggler
+  namespace: argocd # This is the namespace where Argo CD is running
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default # Your Argo CD project
+
+  source:
+    repoURL: https://github.com/Neilrw86/k8s-jiggler.git # The Git repository URL where your chart is located
+    path: k8s-jiggler # The path to your Helm chart directory within the repository
+    targetRevision: HEAD # Or a specific branch, tag, or commit hash (e.g., main, v0.1.0)
+
+    helm:
+      # You can override values from your chart's values.yaml here if needed.
+      # For example:
+      # values: |
+      #   replicaCount: 2
+      #   jiggler:
+      #     namespace: "my-app-namespace" # Override the namespace k8s-jiggler watches
+      #   ingress:
+      #     hosts:
+      #       - host: "jiggler.my-custom-domain.com"
+      #     tls:
+      #       - secretName: jiggler-my-custom-domain-tls
+      #         hosts:
+      #           - "jiggler.my-custom-domain.com"
+      passCredentials: false # Set to true if your repository is private and credentials are required
+
+  destination:
+    server: https://kubernetes.default.svc # Target Kubernetes cluster (default is the same cluster as Argo CD)
+    namespace: k8s-jiggler # The namespace where k8s-jiggler will be deployed
+
+  syncPolicy:
+    automated:
+      prune: true    # Allows Argo CD to delete resources that are no longer defined in the chart
+      selfHeal: true # Allows Argo CD to correct drift from the desired state
+    syncOptions:
+      - CreateNamespace=true # Ensures the destination namespace is created if it doesn't exist
+      # - ServerSideApply=true # Recommended for Kubernetes 1.16+ to improve apply/sync reliability

--- a/argocd-apps/apps/jiggler-app.yaml
+++ b/argocd-apps/apps/jiggler-app.yaml
@@ -14,24 +14,21 @@ spec:
     targetRevision: HEAD # Or a specific branch, tag, or commit hash (e.g., main, v0.1.0)
 
     helm:
-      # You can override values from your chart's values.yaml here if needed.
-      # For example:
-      # values: |
-      #   replicaCount: 2
-      #   jiggler:
-      #     namespace: "my-app-namespace" # Override the namespace k8s-jiggler watches
-      #   ingress:
-      #     hosts:
-      #       - host: "jiggler.my-custom-domain.com"
-      #     tls:
-      #       - secretName: jiggler-my-custom-domain-tls
-      #         hosts:
-      #           - "jiggler.my-custom-domain.com"
+      # Example: To make k8s-jiggler only watch pods within its own deployment namespace ('k8s-jiggler')
+      values: |
+        jiggler:
+          namespace: "default" # Tell the app to watch the 'default' namespace
+        rbac:
+          clusterScoped: false # Create a namespaced Role/RoleBinding instead of ClusterRole/ClusterRoleBinding
+        # ingress: # You might also adjust ingress if it's only for this namespace
+        #   hosts:
+        #     - host: "jiggler.internal.neilwylie.com" # Example for an internal-only jiggler
+        #   # ... other ingress/tls settings ...
       passCredentials: false # Set to true if your repository is private and credentials are required
 
   destination:
     server: https://kubernetes.default.svc # Target Kubernetes cluster (default is the same cluster as Argo CD)
-    namespace: k8s-jiggler # The namespace where k8s-jiggler will be deployed
+    namespace: default # The namespace where k8s-jiggler will be deployed
 
   syncPolicy:
     automated:

--- a/argocd-apps/apps/jiggler-app.yaml
+++ b/argocd-apps/apps/jiggler-app.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   project: default # Your Argo CD project
 
-  source:
-    repoURL: https://github.com/Neilrw86/k8s-jiggler.git # The Git repository URL where your chart is located
+  source: # Source for the k8s-jiggler Helm chart
+    repoURL: https://github.com/Neilrw86/Nas-Automation.git # This should be your Nas-Automation repo
     path: helm_charts/k8s-jiggler # The path to your Helm chart directory within the repository
     targetRevision: June # Or a specific branch, tag, or commit hash (e.g., main, v0.1.0)
 

--- a/helm_charts/k8s-jiggler/.helmignore
+++ b/helm_charts/k8s-jiggler/.helmignore
@@ -1,0 +1,17 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS directories
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig

--- a/helm_charts/k8s-jiggler/Chart.yaml
+++ b/helm_charts/k8s-jiggler/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: k8s-jiggler
+description: A Helm chart for Kubernetes Jiggler, an application that periodically deletes selected pods.
+type: application
+version: 0.1.0
+appVersion: "main" # Corresponds to the Docker image tag being used

--- a/helm_charts/k8s-jiggler/templates/NOTES.txt
+++ b/helm_charts/k8s-jiggler/templates/NOTES.txt
@@ -1,0 +1,44 @@
+{{- $fullName := include "k8s-jiggler.fullname" . -}}
+{{- $ingressHost := "" }}
+{{- if and .Values.ingress.enabled (first .Values.ingress.hosts).host }}
+  {{- $ingressHost = (first .Values.ingress.hosts).host }}
+{{- end }}
+{{- $servicePort := .Values.service.port -}}
+{{- $targetPort := .Values.service.targetPort -}}
+
+k8s-jiggler has been deployed.
+
+{{- if .Values.ingress.enabled }}
+  {{- if $ingressHost }}
+To access k8s-jiggler, ensure you have DNS configured for '{{ $ingressHost }}'
+pointing to your Ingress controller's external IP.
+
+You can then access its health endpoint at: http{{ if .Values.ingress.tls }}s{{ end }}://{{ $ingressHost }}/healthz
+  {{- else }}
+Ingress is enabled, but no host is configured. Please check your values.yaml.
+  {{- end }}
+{{- else }}
+k8s-jiggler is not exposed externally via Ingress. You can use port-forwarding to access it:
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "k8s-jiggler.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Forwarding to pod $POD_NAME in namespace {{ .Release.Namespace }}"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ $servicePort }}:{{ $targetPort }}
+
+Then open http://localhost:{{ $servicePort }}/healthz in your browser.
+{{- end }}
+
+k8s-jiggler is configured to:
+- Watch namespace(s): {{ if .Values.rbac.clusterScoped }}{{ .Values.jiggler.namespace | default "all (cluster-wide)" }}{{ else }}{{ include "k8s-jiggler.rbac.namespace" . }}{{ end }}
+- Jiggle interval: {{ .Values.jiggler.interval }}
+- Label selector for pods: {{ .Values.jiggler.labelSelector }}
+- Mark processed pods with annotation: {{ .Values.jiggler.markProcessed }}
+
+{{- if .Values.rbac.create }}
+Service Account '{{ include "k8s-jiggler.serviceAccountName" . }}' has been created.
+{{- if .Values.rbac.clusterScoped }}
+  - ClusterRole '{{ $fullName }}-clusterrole' and ClusterRoleBinding '{{ $fullName }}-clusterrolebinding' grant cluster-wide access.
+{{- else }}
+  - Role '{{ $fullName }}-role' and RoleBinding '{{ $fullName }}-rolebinding' grant access within namespace '{{ include "k8s-jiggler.rbac.namespace" . }}'.
+{{- end }}
+Permissions include: list, watch, delete pods{{ if .Values.jiggler.markProcessed }}, and patch pods{{ end }}.
+{{- end }}

--- a/helm_charts/k8s-jiggler/templates/_helpers.tpl
+++ b/helm_charts/k8s-jiggler/templates/_helpers.tpl
@@ -1,0 +1,87 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-jiggler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If DNS name is longer than 63 chars, we truncate it on the right.
+*/}}
+{{- define "k8s-jiggler.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-jiggler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "k8s-jiggler.labels" -}}
+helm.sh/chart: {{ include "k8s-jiggler.chart" . }}
+{{ include "k8s-jiggler.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "k8s-jiggler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8s-jiggler.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "k8s-jiggler.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "k8s-jiggler.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate API version for RBAC resources.
+*/}}
+{{- define "k8s-jiggler.rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
+rbac.authorization.k8s.io/v1
+{{- else -}}
+rbac.authorization.k8s.io/v1beta1
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine the namespace for RBAC Role and RoleBinding if not cluster-scoped.
+If jiggler.namespace is set and rbac.clusterScoped is false, use jiggler.namespace.
+Otherwise (if jiggler.namespace is not set or rbac.clusterScoped is true), use the release namespace for the Role/RoleBinding.
+This ensures the Role is created in the namespace the jiggler is intended to watch if specified.
+*/}}
+{{- define "k8s-jiggler.rbac.namespace" -}}
+{{- if and .Values.jiggler.namespace (not .Values.rbac.clusterScoped) -}}
+{{- .Values.jiggler.namespace -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}

--- a/helm_charts/k8s-jiggler/templates/deployment.yaml
+++ b/helm_charts/k8s-jiggler/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "k8s-jiggler.fullname" . }}
+  labels:
+    {{- include "k8s-jiggler.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "k8s-jiggler.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "k8s-jiggler.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "k8s-jiggler.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: JIGGLER_NAMESPACE
+              # If clusterScoped RBAC, use jiggler.namespace (empty means all namespaces for the app)
+              # If namespaced RBAC, JIGGLER_NAMESPACE must be the namespace where Role is defined.
+              value: {{ if .Values.rbac.clusterScoped }}{{ .Values.jiggler.namespace | quote }}{{ else }}{{ include "k8s-jiggler.rbac.namespace" . | quote }}{{ end }}
+            - name: JIGGLER_INTERVAL
+              value: {{ .Values.jiggler.interval | quote }}
+            - name: JIGGLER_LABEL_SELECTOR
+              value: {{ .Values.jiggler.labelSelector | quote }}
+            - name: JIGGLER_MARK_PROCESSED
+              value: {{ .Values.jiggler.markProcessed | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm_charts/k8s-jiggler/templates/ingress.yaml
+++ b/helm_charts/k8s-jiggler/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "k8s-jiggler.fullname" . }}
+  labels:
+    {{- include "k8s-jiggler.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "k8s-jiggler.fullname" $ }}
+                port:
+                  name: http # Refers to the service port name 'http'
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/helm_charts/k8s-jiggler/templates/rbac.yaml
+++ b/helm_charts/k8s-jiggler/templates/rbac.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.clusterScoped }}
+apiVersion: {{ include "k8s-jiggler.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "k8s-jiggler.fullname" . }}-clusterrole
+  labels:
+    {{- include "k8s-jiggler.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""] # Core API group
+  resources: ["pods"]
+  verbs: ["list", "watch", "delete"]
+{{- if .Values.jiggler.markProcessed }}
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["patch"]
+{{- end }}
+---
+apiVersion: {{ include "k8s-jiggler.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "k8s-jiggler.fullname" . }}-clusterrolebinding
+  labels:
+    {{- include "k8s-jiggler.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "k8s-jiggler.fullname" . }}-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ include "k8s-jiggler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- else }}
+# Role and RoleBinding for namespaced operation
+apiVersion: {{ include "k8s-jiggler.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "k8s-jiggler.fullname" . }}-role
+  namespace: {{ include "k8s-jiggler.rbac.namespace" . }}
+  labels:
+    {{- include "k8s-jiggler.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "watch", "delete"]
+{{- if .Values.jiggler.markProcessed }}
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["patch"]
+{{- end }}
+---
+apiVersion: {{ include "k8s-jiggler.rbac.apiVersion" . }}
+kind: RoleBinding
+metadata:
+  name: {{ include "k8s-jiggler.fullname" . }}-rolebinding
+  namespace: {{ include "k8s-jiggler.rbac.namespace" . }}
+  labels:
+    {{- include "k8s-jiggler.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "k8s-jiggler.fullname" . }}-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "k8s-jiggler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }} # ServiceAccount is always in the release namespace
+{{- end }}
+{{- end }}

--- a/helm_charts/k8s-jiggler/templates/service.yaml
+++ b/helm_charts/k8s-jiggler/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "k8s-jiggler.fullname" . }}
+  labels:
+    {{- include "k8s-jiggler.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http # Refers to the container port name 'http' in deployment
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "k8s-jiggler.selectorLabels" . | nindent 4 }}

--- a/helm_charts/k8s-jiggler/templates/serviceaccount.yaml
+++ b/helm_charts/k8s-jiggler/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "k8s-jiggler.serviceAccountName" . }}
+  labels:
+    {{- include "k8s-jiggler.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/helm_charts/k8s-jiggler/values.yaml
+++ b/helm_charts/k8s-jiggler/values.yaml
@@ -54,10 +54,15 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
+    - host: "summer.neilwylie.com" # Your new desired hostname
+      paths:
+        - path: /
+          pathType: Prefix
   tls:
     - secretName: jiggler-tls # TLS secret for jiggler.neilwylie.com
       hosts:
         - "jiggler.neilwylie.com"
+        - "summer.neilwylie.com"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/helm_charts/k8s-jiggler/values.yaml
+++ b/helm_charts/k8s-jiggler/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/neilrw86/k8s-jiggler
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # tag is derived from Chart.appVersion by default if left empty
   tag: ""
 

--- a/helm_charts/k8s-jiggler/values.yaml
+++ b/helm_charts/k8s-jiggler/values.yaml
@@ -36,7 +36,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80 # External port for the service
-  targetPort: 8080 # Port on the pod k8s-jiggler listens on
+  targetPort: 80 # Port on the pod k8s-jiggler listens on
 
 ingress:
   enabled: true

--- a/helm_charts/k8s-jiggler/values.yaml
+++ b/helm_charts/k8s-jiggler/values.yaml
@@ -1,0 +1,104 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/neilrw86/k8s-jiggler
+  pullPolicy: IfNotPresent
+  # tag is derived from Chart.appVersion by default if left empty
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80 # External port for the service
+  targetPort: 8080 # Port on the pod k8s-jiggler listens on
+
+ingress:
+  enabled: true
+  className: "nginx" # Your Ingress controller class
+  annotations:
+    # Nginx Ingress specific annotations
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    # Cert-manager annotations for SSL
+    cert-manager.io/cluster-issuer: "letsencrypt-prod-cfdns" # Your cert-manager ClusterIssuer
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: "jiggler.neilwylie.com" # Your desired hostname
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: jiggler-tls # TLS secret for jiggler.neilwylie.com
+      hosts:
+        - "jiggler.neilwylie.com"
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# k8s-jiggler specific configuration
+jiggler:
+  # Namespace to watch for pods. If empty or not set, k8s-jiggler watches all namespaces (requires rbac.clusterScoped=true).
+  # If set and rbac.clusterScoped=false, k8s-jiggler will watch this specific namespace.
+  namespace: ""
+  # Interval to check for pods. (e.g., "30s", "1m", "2h")
+  interval: "60s"
+  # Label selector to find pods to jiggle.
+  labelSelector: "jiggler/jiggle"
+  # If true, k8s-jiggler will attempt to patch processed pods with an annotation "jiggler/status: jiggled".
+  # This requires 'patch' permission on pods (included in RBAC if this is true).
+  markProcessed: false
+
+rbac:
+  # Specifies whether RBAC resources (ServiceAccount, Role/ClusterRole, RoleBinding/ClusterRoleBinding) should be created
+  create: true
+  # If true, creates ClusterRole and ClusterRoleBinding for cluster-wide permissions.
+  # If false, creates Role and RoleBinding (scoped to jiggler.namespace or the Helm release namespace).
+  # For k8s-jiggler to watch all namespaces (when jiggler.namespace=""), this must be true.
+  clusterScoped: true

--- a/kubernetes/apps/kiali-cr.yaml
+++ b/kubernetes/apps/kiali-cr.yaml
@@ -5,18 +5,12 @@ metadata:
   namespace: istio-system # Kiali server will be deployed in istio-system
 spec:
   auth:
-    strategy: anonymous # For easy testing, change to 'login' for production
+    strategy: anonymous
   external_services:
     prometheus:
-      url: http://prometheus-stack-kube-prome-prometheus.monitoring.svc.cluster.local:9090
+      url: http://kube-prom-stack-kube-prome-prometheus.observability.svc.cluster.local:9090 # Corrected Prometheus URL
     grafana:
-      url: http://prometheus-stack-grafana.monitoring.svc.cluster.local:80
-  server:
-    # Serve Kiali from the root context path for simpler Ingress
-    web_root: /
+      url: http://kube-prom-stack-grafana.observability.svc.cluster.local:80 # Corrected Grafana URL
   deployment:
     node_selector:
       kubernetes.io/arch: amd64 # Adjust if you're not on amd64 (e.g., arm64)
-    # The Kiali operator will pick these up automatically if not set
-    # image_name: quay.io/kiali/kiali
-    # image_version: v1.x.x # The operator typically installs the same version as itself

--- a/kubernetes/apps/kiali-cr.yaml
+++ b/kubernetes/apps/kiali-cr.yaml
@@ -1,0 +1,22 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: istio-system # Kiali server will be deployed in istio-system
+spec:
+  auth:
+    strategy: anonymous # For easy testing, change to 'login' for production
+  external_services:
+    prometheus:
+      url: http://prometheus-stack-kube-prome-prometheus.monitoring.svc.cluster.local:9090
+    grafana:
+      url: http://prometheus-stack-grafana.monitoring.svc.cluster.local:80
+  server:
+    # Serve Kiali from the root context path for simpler Ingress
+    web_root: /
+  deployment:
+    node_selector:
+      kubernetes.io/arch: amd64 # Adjust if you're not on amd64 (e.g., arm64)
+    # The Kiali operator will pick these up automatically if not set
+    # image_name: quay.io/kiali/kiali
+    # image_version: v1.x.x # The operator typically installs the same version as itself

--- a/kubernetes/apps/observability/grafana-ingress.yml
+++ b/kubernetes/apps/observability/grafana-ingress.yml
@@ -4,13 +4,14 @@ metadata:
   name: grafana-ingress
   namespace: observability
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod-cfdns" # Instruct cert-manager to use this issuer
-    kubernetes.io/ingress.class: "nginx" # Specify NGINX as the Ingress controller
+    cert-manager.io/cluster-issuer: "letsencrypt-prod-cfdns"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true" # Redirect HTTP to HTTPS
     # If Grafana itself is serving HTTP on port 80, you might not need backend-protocol: "HTTPS"
+    # kubernetes.io/ingress.class: "nginx" # This is the older annotation
 spec:
+  ingressClassName: nginx # Modern way to specify the Ingress controller
   rules:
-  - host: grafana.neilwylie.com
+  - host: grafana.neilwylie.com # This was missing
     http:
       paths:
       - path: /

--- a/kubernetes/ingresses/kiali-ingress.yaml
+++ b/kubernetes/ingresses/kiali-ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kiali-ingress
+  namespace: istio-system # Kiali is in istio-system, so Ingress is co-located
+  annotations:
+    # Nginx Ingress specific annotations
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true" # Optional, but recommended
+    # Add other relevant Nginx annotations if needed, e.g., for proxy timeouts
+    # Cert-manager annotations for SSL
+    cert-manager.io/cluster-issuer: "letsencrypt-prod-cfdns" # Your cert-manager ClusterIssuer
+spec:
+  ingressClassName: nginx # Your Ingress controller
+  rules:
+    - host: "kiali.neilwylie.com" # Replace with your desired hostname
+      http:
+        paths:
+          - path: / # Kiali will be accessible at the root of the host
+            pathType: Prefix
+            backend:
+              service:
+                name: kiali      # Kiali service name (default)
+                port:
+                  number: 20001  # Kiali service port (default)
+  tls:
+    - hosts:
+        - "kiali.neilwylie.com" # Must match the host in rules
+      secretName: kiali-tls # cert-manager will create/use this secret for the SSL certificate


### PR DESCRIPTION
This pull request introduces a Helm chart for deploying the `k8s-jiggler` application, updates configurations for observability tools like Grafana and Kiali, and improves ingress settings across several Kubernetes resources. The most important changes include the creation of the Helm chart for `k8s-jiggler`, enhancements to ingress configurations, and updates to observability-related resources.

### Helm Chart for `k8s-jiggler` Deployment:
* Added a new Helm chart (`helm_charts/k8s-jiggler`) to deploy the `k8s-jiggler` application, including templates for deployment, service, ingress, RBAC, and service account. This chart allows flexible configuration for namespace watching, pod deletion intervals, and RBAC permissions. [[1]](diffhunk://#diff-36ca831f487cd639cc6648740c2789bf140171d6cb8706693416db2f3d0577cdR1-R77) [[2]](diffhunk://#diff-1fcf0ea192f96950c868aa4530a2a4b79740c07b6ca271b8adae60bf8c6dedb7R1-R15) [[3]](diffhunk://#diff-62ff933fc0cecc9685965cedcb2d6366818224f459723f93c48eeab4db63565dR1-R41) [[4]](diffhunk://#diff-07a3d2bd9a8fa91959f9791a09166eafe6c47a0d192771a7baf87d0b319d4cb9R1-R68) [[5]](diffhunk://#diff-f55d57b1991fea59e294c9a81e2a3029d86c1b6b2a66a35117bedfa2e1e16954R1-R12)
* Defined `values.yaml` for the Helm chart to enable customization of resources, ingress settings, autoscaling, and application-specific configurations like label selectors and processing annotations.
* Added `_helpers.tpl` for reusable template functions to simplify naming conventions and RBAC namespace determination.

### Ingress Configuration Updates:
* Created an ingress resource for `kiali` in `istio-system` namespace with SSL redirection and cert-manager annotations for TLS.
* Updated Grafana ingress to use `ingressClassName` for specifying the NGINX ingress controller, replacing the older annotation. Added missing host information for clarity.

### Observability Enhancements:
* Added a `Kiali` custom resource in `kubernetes/apps/kiali-cr.yaml` with corrected URLs for Prometheus and Grafana integrations. Configured anonymous authentication and node selector for deployment.

### Additional Changes:
* Added `.helmignore` to exclude unnecessary files during Helm package builds, improving chart cleanliness.
* Included `NOTES.txt` in the Helm chart to provide deployment instructions and configuration details for users.